### PR TITLE
Add umockdev developer martinpitt

### DIFF
--- a/developers.list
+++ b/developers.list
@@ -16,3 +16,4 @@ mc-house
 adamretter
 xiejiss
 Xinlong-Wu
+martinpitt


### PR DESCRIPTION
For debugging & testing umockdev on RISC-V architecture.