### PR TITLE
Adding developer for Slackware-riscv64

### DIFF
--- a/developers.list
+++ b/developers.list
@@ -53,3 +53,4 @@ mengzhuo # https://mzh.io/id_ed25519.pub
 realqhc
 sashimi-yzh
 TinySnow
+fede2cr


### PR DESCRIPTION
Adding developer for Slackware-riscv64 (https://github.com/fede2cr/slackware_riscv) and also for starting to work on CBL-Mariner riscv64 port.